### PR TITLE
Rabbitmq Script Compatibility Fix

### DIFF
--- a/InstallScripts/rabbitmq-setup.sh
+++ b/InstallScripts/rabbitmq-setup.sh
@@ -30,7 +30,14 @@ echo $CODENAME
 apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
 wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo apt-key add -
 
-echo "deb https://dl.bintray.com/rabbitmq/debian $CODENAME main erlang" | sudo tee /etc/apt/sources.list.d/bintray.rabbitmq.list
+rm /etc/apt/sources.list.d/bintray.rabbitmq.list
+if [ CODENAME="trusty" ]; then
+	CODENAME=testing
+else
+	echo "deb https://dl.bintray.com/rabbitmq-erlang/debian $CODENAME erlang" | tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
+fi
+echo "deb https://dl.bintray.com/rabbitmq/debian $CODENAME main" | tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
+
 (
 	apt-get update
 	apt-get install -y \


### PR DESCRIPTION
### Changes

2 Issues are addressed, expand individual commit messages for more elaboration:

- Some versions of `os_release` don't have `$UBUNTU_CODENAME`, so the version is wrong. Fixed by checking the version ID instead.
- The bintray repos of rabbitmq's erlang versions don't support `trusty`(Ubuntu 14.04 distributions like Mint 17). Fixed by making the script download the `testing` versions of `rabbitmq-server` instead, which is how we have travis set up and how it works on Hermes. 

Fixes #91 